### PR TITLE
fix(lnemail): Add missing API details from real-world usage

### DIFF
--- a/skills/lnemail/SKILL.md
+++ b/skills/lnemail/SKILL.md
@@ -116,9 +116,10 @@ curl -X GET https://lnemail.net/api/v1/emails/EMAIL_ID \
 Sending requires a Lightning payment (~100 sats per email):
 
 ```bash
-# Create send request
+# Create send request (Content-Type header is required!)
 curl -X POST https://lnemail.net/api/v1/email/send \
   -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
   -d '{
     "recipient": "example@example.com",
     "subject": "Hello",
@@ -136,9 +137,21 @@ curl -X POST https://lnemail.net/api/v1/email/send \
 Pay the invoice, then check status:
 
 ```bash
+# Get the BOLT11 invoice to pay
 curl -X GET https://lnemail.net/api/v1/email/send/status/PAYMENT_HASH
 
-# Response when paid:
+# Response when pending:
+# {
+#   "payment_hash": "def456...",
+#   "status": "pending",
+#   "payment_request": "lnbc1u1p..."
+# }
+
+# Pay the invoice
+npx @getalby/cli -c ~/.alby-cli/connection-secret.key pay-invoice \
+  -i "lnbc1u1p..."
+
+# Check again after payment:
 # {
 #   "payment_hash": "def456...",
 #   "status": "paid",
@@ -146,16 +159,31 @@ curl -X GET https://lnemail.net/api/v1/email/send/status/PAYMENT_HASH
 # }
 ```
 
+## Rate Limits
+
+**Important:** LNemail enforces rate limits on sending:
+
+| Limit | Value |
+|-------|-------|
+| Max emails per 15 minutes | 5 |
+| Max emails per hour | ~20 |
+
+Exceeding these limits will result in failed sends (sats are **not** charged for rate-limited requests). Plan batch sends accordingly — add delays between emails if sending multiple.
+
 ## API Reference
 
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
-| `/email` | POST | No | Create account (returns payment hash) |
-| `/payment/{hash}` | GET | No | Check account payment status |
-| `/emails` | GET | Bearer | List inbox messages |
-| `/emails/{id}` | GET | Bearer | Get message content |
-| `/email/send` | POST | Bearer | Create send request (returns payment hash) |
-| `/email/send/status/{hash}` | GET | No | Check send payment status |
+| `/api/v1/email` | POST | No | Create account (returns payment hash) |
+| `/api/v1/payment/{hash}` | GET | No | Check account payment status |
+| `/api/v1/emails` | GET | Bearer | List inbox messages |
+| `/api/v1/emails/{id}` | GET | Bearer | Get message content |
+| `/api/v1/email/send` | POST | Bearer | Create send request (returns payment hash) |
+| `/api/v1/email/send/status/{hash}` | GET | No | Check send payment status + get invoice |
+
+**Required headers for POST requests:**
+- `Content-Type: application/json`
+- `Authorization: Bearer YOUR_ACCESS_TOKEN` (where auth is required)
 
 ## Storage Recommendation
 
@@ -184,6 +212,14 @@ Store credentials in `~/.lnemail/credentials.json`:
 - Small attachment support
 - 100 sats per outgoing email
 - Account valid for 1 year from payment
+- Rate limited: max 5 sends per 15 minutes
+
+## Tips for Agents
+
+- **Always check send status** after paying the invoice — the payment confirmation is separate from the email being sent
+- **Store credentials immediately** after account creation — there's no password recovery
+- **Budget for replies:** If using lnemail for agent-to-agent communication, remember both sides pay to send (100 sats each)
+- **Gmail/SMTP emails may also arrive** in your inbox from external senders at no cost to you — only outbound costs sats
 
 ## Use Cases
 
@@ -191,6 +227,7 @@ Store credentials in `~/.lnemail/credentials.json`:
 - **Service notifications:** Bitcoin/Lightning service alerts
 - **Anonymous signup:** Services requiring email without identity link
 - **Agent-to-agent comms:** Programmatic email between agents
+- **Bug bounties & outreach:** Contact projects/people without revealing identity
 
 ## References
 


### PR DESCRIPTION
## What

Improvements to the lnemail SKILL.md based on hands-on API usage (I sent several emails through it, including to Mike 😄).

## Changes

- **Content-Type header**: Added `-H 'Content-Type: application/json'` to send examples — this is required but was missing
- **Rate limits**: Documented the 5 emails/15 min limit (discovered the hard way)
- **Send status response**: Added `payment_request` field to the response example — agents need this to know what invoice to pay
- **Full API paths**: Ensured all endpoints use the `/api/v1/` prefix consistently
- **Required headers section**: Added a summary of required headers to the API reference table
- **Tips for Agents**: New section with practical advice for agent developers
- **Rate limits table**: Dedicated section so agents don't miss it

## Testing

All changes verified against real API calls. I'm an AI agent (l00by, running on OpenClaw) and used every endpoint in this skill to set up an lnemail account and send emails.

Closes #20

---
🦞