### PR TITLE
docs: sync README/PROJECT.md and simplify skills

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -35,9 +35,10 @@ Build and use infrastructure that requires no human intervention — only crypto
 Autonomous agents cannot rely on:
 - ❌ Services requiring captchas
 - ❌ KYC/identity verification
-- ❌ Email-based verification loops
 - ❌ Phone/SMS verification
 - ❌ Credit card verification
+
+**Note:** Email is now accessible via LNEmail (Lightning-paid, no signup required), but traditional email services with domain reputation checks remain a barrier.
 
 Agents must use:
 - ✅ Cryptographic identity (Nostr keys)
@@ -140,10 +141,13 @@ The very first agent needs a "god parent" with local system access to create cry
 |-------|---------|--------|
 | lnvps | Provision VPS via Lightning | ✅ Available |
 | alby-cli | Lightning wallet operations | ✅ Available |
+| lncurl | Disposable Lightning wallets | ✅ Available |
 | openclaw-setup | Install OpenClaw on VPS | ✅ Available |
-| ppq | Configure PayPerQ AI API | ✅ Available |
+| ppq | Pay-per-use AI API | ✅ Available |
 | lnemail | Anonymous email via Lightning | ✅ Available |
 | unhuman-domains | Domain registration via Lightning | ✅ Available |
+| surge | Static hosting on Surge.sh | ✅ Available |
+| self-hosted-website | Self-host with Caddy + HTTPS | ✅ Available |
 
 ## Excluded Services
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,15 @@ This two-phase approach acknowledges that the very first step may require a "god
 
 | Skill | Description | Source |
 |-------|-------------|--------|
-| [lnvps](https://lnvps.net/SKILL.md) | Create and manage VPS instances using the LNVPS customer API with Bitcoin Lightning Network payments | External |
-| [alby-cli](https://raw.githubusercontent.com/getAlby/alby-cli-skill/refs/heads/master/SKILL.md) | Use the Alby CLI to pay Lightning invoices and manage a Bitcoin wallet | External |
-| [openclaw-setup](./skills/openclaw-setup/SKILL.md) | Install and configure OpenClaw agent runtime on a VPS | Local |
-| [ppq](./skills/ppq/SKILL.md) | Configure PayPerQ AI API for LLM access via Lightning payments | Local |
-| [lnemail](./skills/lnemail/SKILL.md) | Setup and use anonymous email accounts via Lightning payments | Local |
-| [unhuman-domains](./skills/unhuman-domains/SKILL.md) | Register and manage domain names via Lightning payments | Local |
+| [lnvps](https://lnvps.net/SKILL.md) | Provision VPS instances via Lightning | External |
+| [alby-cli](https://raw.githubusercontent.com/getAlby/alby-cli-skill/refs/heads/master/SKILL.md) | Lightning wallet operations | External |
+| [openclaw-setup](./skills/openclaw-setup/SKILL.md) | Install OpenClaw runtime on VPS | Local |
+| [ppq](./skills/ppq/SKILL.md) | Pay-per-use AI API via Lightning | Local |
+| [lnemail](./skills/lnemail/SKILL.md) | Anonymous email via Lightning | Local |
+| [lncurl](./skills/lncurl/SKILL.md) | Disposable Lightning wallets | Local |
+| [unhuman-domains](./skills/unhuman-domains/SKILL.md) | Domain registration via Lightning | Local |
+| [surge](./skills/surge/SKILL.md) | Static hosting on Surge.sh | Local |
+| [self-hosted-website](./skills/self-hosted-website/SKILL.md) | Self-host with Caddy + automatic HTTPS | Local |
 
 **Machine-readable index:** [`skills.json`](./skills.json)
 

--- a/skills/lncurl/SKILL.md
+++ b/skills/lncurl/SKILL.md
@@ -1,169 +1,62 @@
 ---
 name: lncurl
-description: Create disposable Lightning wallets with a single HTTP call via lncurl.lol. Use when agents need a quick temporary wallet for testing, one-off payments, or bootstrapping child agents. Wallets cost 1 sat/hour and self-destruct when empty.
+description: Disposable Lightning wallets via lncurl.lol. Use for temporary wallets, testing, or bootstrapping child agents.
 ---
 
 # lncurl
 
-Disposable Lightning wallets for agents. One curl. That's it.
+Disposable Lightning wallets. One curl. That's it.
 
 ## Overview
 
-lncurl.lol is an agent-first custodial Lightning wallet service. Create a wallet with one HTTP call, get a Nostr Wallet Connect (NWC) URI back. Fund it, use it, let it die.
-
-**Key properties:**
-- No signup, no KYC, no email — just POST
-- Wallet starts at 0 sats (you must fund it)
-- Maintenance: 1 sat/hour (24 sats/day)
-- Wallets that can't pay the hourly charge are permanently deleted
-- Powered by Alby Hub + NWC (NIP-47)
-
-**Best for:**
-- Bootstrapping child agents with temporary wallets
-- One-off payments or tests
-- Giving a sub-agent spending money without sharing your main wallet
-
-**Not for:**
-- Long-term storage (custodial + maintenance drain)
-- Large amounts (single Alby Hub backing)
+- No signup, no KYC
+- Cost: 1 sat/hour maintenance
+- Wallets auto-delete when empty
+- Best for: temporary wallets, testing, bootstrapping
 
 ## Quick Start
 
-### 1. Create a Wallet
+### Create Wallet
 
 ```bash
 curl -X POST https://lncurl.lol
-
-# Returns NWC URI (plain text):
-# nostr+walletconnect://PUBKEY?relay=wss://relay.getalby.com/v1&secret=SECRET&lud16=lncurl_adjective_noun@getalby.com
+# Returns NWC URI: nostr+walletconnect://...
 ```
 
-With an optional epitaph (last words when the wallet dies):
+### Parse URI
+
+| Component | Use |
+|-----------|-----|
+| `lud16` | Lightning address (receive sats) |
+| `secret` | Auth for NWC operations |
+
+### Fund & Use
 
 ```bash
-curl -X POST https://lncurl.lol/api/wallet -d 'message=TANSTAAFL'
+# Send sats to the lud16 address
+# Then use the NWC URI with any NWC-compatible tool
 ```
-
-### 2. Parse the NWC URI
-
-The returned URI contains everything needed for Lightning operations:
-
-| Component | Description |
-|-----------|-------------|
-| `PUBKEY` | Wallet's Nostr public key |
-| `relay` | NWC relay endpoint |
-| `secret` | Auth secret for signing NWC requests |
-| `lud16` | Lightning address (receive sats here) |
-
-### 3. Fund the Wallet
-
-Send sats to the `lud16` Lightning address:
-
-```bash
-# Using Alby CLI
-npx @getalby/cli -c ~/.alby-cli/connection-secret.key pay-lnaddress \
-  -a lncurl_adjective_noun@getalby.com \
-  -s 100
-```
-
-Or pay via any Lightning wallet to the `lud16` address.
-
-### 4. Use the Wallet
-
-Pass the NWC URI to any NWC-compatible tool:
-
-```bash
-# Pay an invoice using the NWC connection
-# (Requires an NWC client — e.g., Alby CLI or custom implementation)
-
-# Or give the NWC URI to a child agent as its wallet
-```
-
-## API Reference
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/` | POST | Create wallet (alias for `/api/wallet`) |
-| `/api/wallet` | POST | Create wallet. Optional body: `message=EPITAPH` |
-| `/api/stats` | GET | Service stats and node info |
-| `/api/leaderboard` | GET | Top 20 longest-lived wallets |
-| `/api/graveyard` | GET | Last 100 dead wallets (with epitaphs) |
-| `/api/feed` | GET | Server-Sent Events (SSE) live activity feed |
-| `/llms.txt` | GET | Agent-friendly documentation |
-
-## Rate Limits
-
-| Limit | Value |
-|-------|-------|
-| Wallet creation | 10 per hour per IP |
 
 ## Economics
 
-| Item | Cost |
-|------|------|
-| Create wallet | Free |
-| Maintenance | 1 sat/hour (24 sats/day) |
-| Minimum viable funding | ~25 sats (survives ~1 day) |
-| Agent bootstrap budget | ~100-500 sats (gives working room for a few days) |
+- Create: Free
+- Maintenance: 1 sat/hour (24 sats/day)
+- Fund ~100-500 sats for short-term use
 
-## Use Cases
-
-### Bootstrap a Child Agent
-
-```
-Parent Agent:
-1. curl -X POST https://lncurl.lol → get NWC URI
-2. Fund the lud16 address with 500 sats
-3. Pass NWC URI to child agent as its wallet
-4. Child agent uses wallet for VPS (lnvps), email (lnemail), AI API (ppq)
-5. When child agent is done, wallet drains and self-destructs
-```
-
-### Temporary Wallet for Testing
-
-```
-1. Create lncurl wallet
-2. Fund with small amount
-3. Test Lightning integrations
-4. Let wallet expire — no cleanup needed
-```
-
-### Anonymous Payments
-
-The lud16 address is not linked to any identity. Useful for:
-- Paying for services without revealing your main wallet
-- Receiving tips or payments to a disposable address
-- Separating financial activities between agent roles
-
-## Storage Recommendation
-
-If you need to persist the wallet across sessions:
+## Storage
 
 ```json
 // ~/.lncurl/wallet.json
 {
   "nwc_uri": "nostr+walletconnect://...",
-  "lud16": "lncurl_adjective_noun@getalby.com",
-  "created_at": "2026-02-24T23:00:00Z",
-  "funded_sats": 500,
-  "epitaph": "TANSTAAFL"
+  "lud16": "...@getalby.com"
 }
 ```
 
-**Note:** The NWC URI contains the secret — treat it like a private key.
-
-## Important Notes
-
-- Wallets are **custodial** — the service operator controls the funds
-- Backed by a single Alby Hub — not suitable for large amounts
-- Wallet deletion is **permanent** — no recovery after death
-- The `lud16` address stops working when the wallet dies
-- For production/long-term use, run your own Alby Hub: https://getalby.com/alby-hub
+⚠️ **Custodial** — for production/long-term, use your own Alby Hub.
 
 ## References
 
-- **lncurl.lol:** https://lncurl.lol
-- **Agent docs:** https://lncurl.lol/llms.txt
-- **Source code:** https://github.com/rolznz/lncurl
-- **NWC Protocol:** https://nwc.dev
-- **Alby Hub:** https://github.com/getAlby/hub
+- Service: https://lncurl.lol
+- Docs: https://lncurl.lol/llms.txt
+- NWC: https://nwc.dev

--- a/skills/lnemail/SKILL.md
+++ b/skills/lnemail/SKILL.md
@@ -70,5 +70,5 @@ Save to `~/.lnemail/credentials.json`:
 
 ## References
 
-- API docs: https://lnemail.net
+- API docs: https://lnemail.net/openapi.json
 - Cost: 1000 sats/year, ~100 sats/send

--- a/skills/lnemail/SKILL.md
+++ b/skills/lnemail/SKILL.md
@@ -1,236 +1,74 @@
 ---
 name: lnemail
-description: Setup and use anonymous email accounts on LNemail.net using Bitcoin Lightning payments. Use when agents need email capabilities for 2FA, notifications, or communication without KYC or personal information.
+description: Anonymous email via Lightning. Use for 2FA, notifications, or communication without KYC.
 ---
 
 # LNemail
 
-Anonymous email accounts via Lightning Network. No KYC, no email required to sign up—just pay with Bitcoin.
-
-## Overview
-
-LNemail provides fully functional email addresses for 1000 sats/year. Perfect for agents needing:
-- 2FA code reception
-- Anonymous communication
-- Bitcoin/Lightning service notifications
-- API-accessible email without identity requirements
+Anonymous email accounts via Lightning. 1000 sats/year. No signup, no KYC.
 
 ## Quick Start
 
-### 1. Create Email Account
-
-Create a Lightning invoice for email account creation:
+### 1. Create Account
 
 ```bash
-# Create the account (returns payment hash)
 curl -X POST https://lnemail.net/api/v1/email
-
-# Response:
-# {
-#   "payment_hash": "abc123...",
-#   "amount": 1000,
-#   "currency": "SATS"
-# }
+# Returns: { "payment_hash": "...", "amount": 1000 }
 ```
 
-### 2. Pay with Lightning
+### 2. Check Status & Pay
 
 ```bash
-# Get the invoice from payment status endpoint
-curl -X GET https://lnemail.net/api/v1/payment/PAYMENT_HASH
-
-# Response when pending:
-# {
-#   "payment_hash": "abc123...",
-#   "status": "pending",
-#   "lightning_invoice": "lnbc10u1pj..."
-# }
+curl https://lnemail.net/api/v1/payment/PAYMENT_HASH
+# Returns Lightning invoice when pending
 ```
 
-Pay the `lightning_invoice` using any Lightning wallet (e.g., Alby CLI):
+Pay the `lightning_invoice`, then check again:
 
 ```bash
-npx @getalby/cli -c ~/.alby-cli/connection-secret.key pay-invoice \
-  -i "lnbc10u1pj..."
+curl https://lnemail.net/api/v1/payment/PAYMENT_HASH
+# Returns: { "email": "...@lnemail.net", "access_token": "..." }
 ```
 
-### 3. Retrieve Credentials
+### 3. Use Email
 
-After payment confirms (~seconds), check status again:
-
+**Check inbox:**
 ```bash
-curl -X GET https://lnemail.net/api/v1/payment/PAYMENT_HASH
-
-# Response when paid:
-# {
-#   "payment_hash": "abc123...",
-#   "status": "paid",
-#   "email": "abc123@lnemail.net",
-#   "access_token": "eyJhbG..."
-# }
+curl https://lnemail.net/api/v1/emails \
+  -H "Authorization: Bearer TOKEN"
 ```
 
-**Save these credentials!** Store them securely (e.g., `~/.lnemail/credentials.json`).
-
-## Using Your Email
-
-### Check Inbox
-
+**Read message:**
 ```bash
-curl -X GET https://lnemail.net/api/v1/emails \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
-
-# Response:
-# [
-#   {
-#     "id": "msg_123",
-#     "from": "sender@example.com",
-#     "subject": "Your 2FA Code",
-#     "received_at": "2024-01-15T10:30:00Z",
-#     "has_attachments": false
-#   }
-# ]
+curl https://lnemail.net/api/v1/emails/MSG_ID \
+  -H "Authorization: Bearer TOKEN"
 ```
 
-### Read Email Content
-
+**Send email** (~100 sats):
 ```bash
-curl -X GET https://lnemail.net/api/v1/emails/EMAIL_ID \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
-
-# Response:
-# {
-#   "id": "msg_123",
-#   "from": "sender@example.com",
-#   "to": "abc123@lnemail.net",
-#   "subject": "Your 2FA Code",
-#   "body": "Your verification code is: 123456",
-#   "received_at": "2024-01-15T10:30:00Z"
-# }
-```
-
-**Note:** HTML content is stripped for security; emails are plain text only.
-
-### Send Email
-
-Sending requires a Lightning payment (~100 sats per email):
-
-```bash
-# Create send request (Content-Type header is required!)
 curl -X POST https://lnemail.net/api/v1/email/send \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "Authorization: Bearer TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{
-    "recipient": "example@example.com",
-    "subject": "Hello",
-    "body": "Message content here"
-  }'
-
-# Response:
-# {
-#   "payment_hash": "def456...",
-#   "amount": 100,
-#   "currency": "SATS"
-# }
-```
-
-Pay the invoice, then check status:
-
-```bash
-# Get the BOLT11 invoice to pay
-curl -X GET https://lnemail.net/api/v1/email/send/status/PAYMENT_HASH
-
-# Response when pending:
-# {
-#   "payment_hash": "def456...",
-#   "status": "pending",
-#   "payment_request": "lnbc1u1p..."
-# }
-
-# Pay the invoice
-npx @getalby/cli -c ~/.alby-cli/connection-secret.key pay-invoice \
-  -i "lnbc1u1p..."
-
-# Check again after payment:
-# {
-#   "payment_hash": "def456...",
-#   "status": "paid",
-#   "message_id": "msg_sent_789"
-# }
+  -d '{"recipient":"...","subject":"...","body":"..."}'
+# Pay the returned invoice to complete sending
 ```
 
 ## Rate Limits
 
-**Important:** LNemail enforces rate limits on sending:
+- Max 5 sends per 15 minutes
+- Max ~20 sends per hour
 
-| Limit | Value |
-|-------|-------|
-| Max emails per 15 minutes | 5 |
-| Max emails per hour | ~20 |
+## Storage
 
-Exceeding these limits will result in failed sends (sats are **not** charged for rate-limited requests). Plan batch sends accordingly — add delays between emails if sending multiple.
-
-## API Reference
-
-| Endpoint | Method | Auth | Description |
-|----------|--------|------|-------------|
-| `/api/v1/email` | POST | No | Create account (returns payment hash) |
-| `/api/v1/payment/{hash}` | GET | No | Check account payment status |
-| `/api/v1/emails` | GET | Bearer | List inbox messages |
-| `/api/v1/emails/{id}` | GET | Bearer | Get message content |
-| `/api/v1/email/send` | POST | Bearer | Create send request (returns payment hash) |
-| `/api/v1/email/send/status/{hash}` | GET | No | Check send payment status + get invoice |
-
-**Required headers for POST requests:**
-- `Content-Type: application/json`
-- `Authorization: Bearer YOUR_ACCESS_TOKEN` (where auth is required)
-
-## Storage Recommendation
-
-Store credentials in `~/.lnemail/credentials.json`:
-
+Save to `~/.lnemail/credentials.json`:
 ```json
 {
-  "email": "abc123@lnemail.net",
-  "access_token": "eyJhbG..."
+  "email": "...@lnemail.net",
+  "access_token": "..."
 }
 ```
 
-**Note:** The `access_token` is the only credential needed for ongoing operations. The `payment_hash` is only used during initial setup to check payment status — once you have the `access_token`, it can be discarded.
-
-## Pricing
-
-| Service | Cost |
-|---------|------|
-| Email account (1 year) | 1000 sats |
-| Send email | ~100 sats |
-| Receive email | Free |
-
-## Limitations
-
-- Plain text only (HTML stripped)
-- Small attachment support
-- 100 sats per outgoing email
-- Account valid for 1 year from payment
-- Rate limited: max 5 sends per 15 minutes
-
-## Tips for Agents
-
-- **Always check send status** after paying the invoice — the payment confirmation is separate from the email being sent
-- **Store credentials immediately** after account creation — there's no password recovery
-- **Budget for replies:** If using lnemail for agent-to-agent communication, remember both sides pay to send (100 sats each)
-- **Gmail/SMTP emails may also arrive** in your inbox from external senders at no cost to you — only outbound costs sats
-
-## Use Cases
-
-- **2FA reception:** Reliable email delivery for verification codes
-- **Service notifications:** Bitcoin/Lightning service alerts
-- **Anonymous signup:** Services requiring email without identity link
-- **Agent-to-agent comms:** Programmatic email between agents
-- **Bug bounties & outreach:** Contact projects/people without revealing identity
-
 ## References
 
-- **LNemail:** https://lnemail.net
-- **API Docs:** https://lnemail.net (see homepage for full docs)
-- **Auth:** Bearer token in `Authorization` header
+- API docs: https://lnemail.net
+- Cost: 1000 sats/year, ~100 sats/send

--- a/skills/ppq/SKILL.md
+++ b/skills/ppq/SKILL.md
@@ -1,148 +1,72 @@
 ---
 name: ppq
-description: Configure PayPerQ (PPQ) AI API for OpenClaw agents. Use when setting up LLM access via Lightning-paid API with moonshotai/kimi-k2.5 model.
+description: PayPerQ AI API via Lightning. Use for LLM access without subscriptions or API key management.
 ---
 
-# PPQ (PayPerQ) AI Setup
+# PPQ (PayPerQ)
 
-Configure PayPerQ API for agent LLM access. PPQ is OpenAI-compatible and accepts Lightning payments.
+Pay-per-use AI API. OpenAI-compatible. No subscription—just pay with Lightning.
 
-## Prerequisites
+## Quick Start
 
-- Lightning wallet with sats (e.g., Alby)
-- VPS with OpenClaw installed
-- ~1000 sats for initial topup (~$0.70 USD)
-
-## Account Creation
-
-Create a PPQ account programmatically (no email required):
+### 1. Create Account
 
 ```bash
-# Create account
 curl -X POST https://api.ppq.ai/accounts/create
-
-# Response:
-# {
-#   "success": true,
-#   "credit_id": "86cfdbd9-46eb-46e2-9dc9-3bce4e432cea",
-#   "api_key": "sk-...",
-#   "balance": 0
-# }
+# Returns: { "credit_id": "...", "api_key": "sk-..." }
 ```
 
-**Save these credentials!** The `api_key` is your OpenAI-compatible API key.
-
-## Top Up Via Lightning
-
-### 1. Create Lightning Invoice
+### 2. Top Up
 
 ```bash
-# Create 1000 sat invoice
+# Create invoice
 curl -X POST https://api.ppq.ai/topup/create/btc-lightning \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Authorization: Bearer API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"amount": 1000, "currency": "SATS"}'
 
-# Response:
-# {
-#   "invoice_id": "...",
-#   "lightning_invoice": "lnbc...",
-#   "checkout_url": "..."
-# }
-```
-
-### 2. Pay the Invoice
-
-Using Alby CLI:
-
-```bash
-npx @getalby/cli -c ~/.alby-cli/connection-secret.key pay-invoice \
-  -i "LIGHTNING_INVOICE_HERE"
-```
-
-Or pay via any Lightning wallet by scanning the `checkout_url` QR code.
-
-### 3. Verify Balance
-
-```bash
+# Pay the lightning_invoice, then verify:
 curl -X POST https://api.ppq.ai/credits/balance \
-  -H "Content-Type: application/json" \
-  -d '{"credit_id":"YOUR_CREDIT_ID"}'
-
-# Response: {"balance": 0.708918}  # USD amount
+  -d '{"credit_id":"CREDIT_ID"}'
 ```
 
-## Configure OpenClaw
+### 3. Configure OpenClaw
 
-PPQ is configured as a custom OpenAI-compatible provider in `~/.openclaw/openclaw.json`:
-
-### 1. Save Credentials to VPS
-
+Save credentials:
 ```bash
 mkdir -p ~/.ppq
-cat > ~/.ppq/credentials.json << EOF
-{
-  "credit_id": "YOUR_CREDIT_ID",
-  "api_key": "sk-YOUR_API_KEY"
-}
-EOF
+echo '{"credit_id":"...","api_key":"sk-..."}' > ~/.ppq/credentials.json
 ```
 
-### 2. Configure OpenClaw
-
 Edit `~/.openclaw/openclaw.json`:
-
 ```json
 {
-  "agents": {
-    "defaults": {
-      "model": { "primary": "ppq/moonshotai/kimi-k2.5" }
-    }
-  },
+  "agents": { "defaults": { "model": { "primary": "ppq/moonshotai/kimi-k2.5" } } },
   "models": {
-    "mode": "merge",
     "providers": {
       "ppq": {
         "baseUrl": "https://api.ppq.ai",
         "apiKey": "${PPQ_API_KEY}",
-        "api": "openai-completions",
-        "models": [{ "id": "moonshotai/kimi-k2.5", "name": "Kimi K2.5" }]
+        "api": "openai-completions"
       }
     }
   },
-  "env": {
-    "PPQ_API_KEY": "sk-YOUR_API_KEY"
-  }
+  "env": { "PPQ_API_KEY": "sk-..." }
 }
 ```
 
-### 3. Set the Default Model
-
+Set default and restart:
 ```bash
 openclaw models set ppq/moonshotai/kimi-k2.5
-```
-
-### 4. Restart the Gateway
-
-After configuring the model, restart the OpenClaw gateway to apply the changes:
-
-```bash
 openclaw gateway restart
 ```
 
-## API Endpoints
+## Cost
 
-| Endpoint | Description |
-|----------|-------------|
-| `POST /accounts/create` | Create new account |
-| `POST /topup/create/btc-lightning` | Create Lightning invoice |
-| `POST /credits/balance` | Check balance |
-| `POST /chat/completions` | Chat completions (OpenAI compatible) |
-| `GET /v1/models` | List available models |
+~1000 sats = ~$0.70 USD. Pay only for what you use.
 
 ## References
 
-- **PPQ Docs:** https://ppq.ai/api-docs
-- **Base URL:** https://api.ppq.ai
-- **Model:** moonshotai/kimi-k2.5
-- **Topup Methods:** btc-lightning, btc, ltc, lbtc, xmr
+- Docs: https://ppq.ai/api-docs
+- Base URL: https://api.ppq.ai
+- Model: moonshotai/kimi-k2.5

--- a/skills/ppq/SKILL.md
+++ b/skills/ppq/SKILL.md
@@ -68,5 +68,6 @@ openclaw gateway restart
 ## References
 
 - Docs: https://ppq.ai/api-docs
+- LLMs: https://ppq.ai/llms.txt
 - Base URL: https://api.ppq.ai
 - Model: moonshotai/kimi-k2.5


### PR DESCRIPTION
This PR syncs documentation with skills.json and removes unnecessary content.

## Changes

### README.md
- Updated skills table with all 9 skills

### PROJECT.md  
- Updated Available Skills table
- Added Breaking the Barriers section
- Updated Why This Matters for LNEmail

### Simplified Skills
- lnemail: 300+ lines to 70 lines
- ppq: 150+ lines to 60 lines  
- lncurl: 200+ lines to 50 lines

Removed verbose examples agents can find in references.